### PR TITLE
Reorganize chapters

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -13,14 +13,15 @@ book:
       chapters:
         - code-of-conduct.qmd
         - group-expectations.qmd
-        - onboarding.qmd
-    - part: "Group Processes"
+    - part: "Group Processes (Agile)"
       chapters:
         - project-management.qmd
         - annual-reviews.qmd
         - quarterly-meetings.qmd
         - sprint-planning.qmd
         - standups.qmd
+    - part: "Gropu Procedures"
+        - onboarding.qmd
         - hiring.qmd
         - professional-development.qmd
     - part: "Group Programming"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,11 +16,12 @@ book:
     - part: "Group Processes (Agile)"
       chapters:
         - project-management.qmd
-        - annual-reviews.qmd
-        - quarterly-meetings.qmd
-        - sprint-planning.qmd
         - standups.qmd
-    - part: "Gropu Procedures"
+        - sprint-planning.qmd 
+        - quarterly-meetings.qmd
+        - annual-reviews.qmd
+    - part: "Group Procedures"
+      chapters:
         - onboarding.qmd
         - hiring.qmd
         - professional-development.qmd

--- a/project-management.qmd
+++ b/project-management.qmd
@@ -1,5 +1,5 @@
 ---
-title: Project Management
+title: Agile overview
 ---
 
 The [Agile process](https://en.wikipedia.org/wiki/Agile_software_development) we use is dynamic.


### PR DESCRIPTION
I propose the following sections, that _should_ fit everything:

1. General Info (or a better name): code of conduct, group expectations
2. Group Processes (Agile): standups, OKRs, sprint planning, etc.
3. Group Procedures: onboarding, offboarding, hiring, getting travel reimbursement, publications and collaborators, anything that's like rules or procedures about how to do things.
4. Group Programing: workshops, incubator projects, drop-in hours
5. Resources: misc stuff like Networking at UA, Creating R packages, Software and Computing Resources