### PR TITLE
Add "Report an Issue" link

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-edit.md
+++ b/.github/ISSUE_TEMPLATE/suggest-edit.md
@@ -3,7 +3,7 @@ name: Suggest an Edit
 about: Suggest an edit to the book
 ---
 
-## Suggest an Edit
+What chapter/section?
 
 What it says now:
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,8 +5,10 @@ book:
   title: "CCT Data Science Group Procedures"
   # cover-image: cover.png
   search: true
+  site-url: https://cct-datascience.github.io/group-procedures/
   repo-url: https://github.com/cct-datascience/group-procedures
-  repo-actions: [edit]
+  repo-actions: [edit, issue, source]
+  issue-url: https://github.com/cct-datascience/group-procedures/issues/new?template=suggest-edit.md
   chapters:
     - index.qmd
     - part: "General Information"


### PR DESCRIPTION
Adds link for opening an issue.  I'd like it to open a _specific_ issue template, but it doesn't work.  Opened a discussion here: https://github.com/quarto-dev/quarto-cli/discussions/7203