### PR TITLE
Add authors and DOI to first page of book

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 
 <!-- Briefly describe any changes to the configuration, code, or github actions in this PR -->
 
-If you are a first time contributor remember to add yourself to CITATION.cff!
+If you are a first time contributor remember to add yourself to CITATION.cff and to the author section in \_quarto.yml!

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,7 @@ authors: # order is [group lead, order of joining, lebauer]
       Technologies Data Science
   - given-names: Julian
     family-names: Pistorius
+    orcid: https://orcid.org/0000-0002-3485-0084
   - given-names: Jorge. E.
     family-names: Barrios
   - given-names: Emily. J.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,44 @@ execute:
   freeze: auto
 book:
   title: "CCT Data Science Group Procedures"
+  doi: 10.17605/OSF.IO/TZMHP
+  author:
+  - name:
+      given: Kristina
+      family: Riemer
+    orcid: 0000-0003-3802-3331
+  - name:
+      given: Kimberly. M.
+      family: Huynh
+  - name:
+      given: Christophe
+      family: Schnaufer
+  - name:
+      given: Julian
+      family: Pistorius
+    orcid: 0000-0002-3485-0084
+  - name:
+      given: Jorge. E.
+      family: Barrios
+  - name:
+      given: Emily. J.
+      family: Cain
+  - name:
+      given: Jessica
+      family: Guo
+    orcid: 0000-0002-9566-9182
+  - name:
+      given: Eric R.
+      family: Scott
+    orcid: 0000-0002-7430-7879
+  - name:
+      given: Renata
+      family: Diaz
+    orcid: 0000-0003-0803-4734
+  - name:
+      given: David S.
+      family: LeBauer
+    orcid: 0000-0001-7228-053X
   # cover-image: cover.png
   search: true
   site-url: https://cct-datascience.github.io/group-procedures/

--- a/index.qmd
+++ b/index.qmd
@@ -1,3 +1,7 @@
+---
+link-external-icon: false
+---
+
 # Purpose {.unnumbered}
 
 This book is to document the processes, resources, and internal workings of the Communications & Cyber Technologies Data Science Team at the University of Arizona.


### PR DESCRIPTION
## Content changes/additions

Adds the authors and DOI to the "cover page" of the book:
![Screenshot 2024-03-07 at 10 24 44 AM](https://github.com/cct-datascience/group-procedures/assets/25404783/5a591a2d-0558-4e6f-a20e-a9774f330fe9)

## Technical changes/additions

Removes the external link icon from that first page, so they don't show up next to every orcid symbol