### PR TITLE
GitHub action to check for broken URLs

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,7 +21,14 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           fail: true
-          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects --exclude calendar\.google\.com --exclude \.php$ './**/*.md' './**/*.qmd'
+          args: >
+            --glob-ignore-case 
+            --exclude docs\.google\.com 
+            --exclude hackmd\.io 
+            --exclude github\.com\/orgs\/cct-datascience\/projects 
+            --exclude calendar\.google\.com 
+            --exclude \.php$ 
+            './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0 & ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,3 +1,6 @@
+# action: https://github.com/lycheeverse/lychee-action
+# lychee: https://github.com/lycheeverse/lychee
+
 name: Links
 
 on:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,7 +21,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           fail: true
-          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects --exclude calendar\.google\.com './**/*.md' './**/*.qmd'
+          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects --exclude calendar\.google\.com --exclude \.php$ './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0 & ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,7 +1,7 @@
 name: Links
 
 on:
-  # pull_request:
+  pull_request:
   workflow_dispatch:
   schedule:
   #every monday
@@ -21,7 +21,7 @@ jobs:
           args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
-        if: env.lychee_exit_code != 0
+        if: env.lychee_exit_code != 0 & ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Link Checker Report

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-  #every monday
-    - cron: "0 0 * * MON"
+  #first of every month
+    - cron: "0 0 1 * *"
 
 jobs:
   linkChecker:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,7 +1,7 @@
 name: Links
 
 on:
-  pull_request:
+  # pull_request:
   workflow_dispatch:
   schedule:
   #every monday
@@ -16,6 +16,9 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1
+        with:
+          fail: true
+          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,7 +21,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           fail: true
-          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects './**/*.md' './**/*.qmd'
+          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects --exclude calendar\.google\.com './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0 & ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           fail: true
-          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io './**/*.md' './**/*.qmd'
+          args: --glob-ignore-case --exclude docs\.google\.com --exclude hackmd\.io --exclude github\.com\/orgs\/cct-datascience\/projects './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0 & ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,7 +1,7 @@
 name: Links
 
 on:
-  repository_dispatch:
+  pull_request:
   workflow_dispatch:
   schedule:
   #every monday

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,26 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+  #every monday
+    - cron: "0 0 * * MON"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
Adds a GitHub action that runs [lychee](https://github.com/lycheeverse/lychee) to check for bad URLs every monday and on pull requests.  

When it is run as a cron job (or with a button-click via "workflow dispatch") it will open an issue regarding broken URLs.  When triggered by a PR it will simply fail without opening an issue (assuming that the PR introduced the bad URLs and they should be fixed before merging it).

Would appreciate feedback on how often this should run.  Perhaps only monthly?

To do:
- [x] deal with private project board URLs (either ignore github.com/orgs/cct-datascience/projects or create a custom token with permissions to see these)
- [x] deal with private google docs and hackmds
- [x] only check source documents, not `_book/`
