### PR TITLE
don't check extensions for broken links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,13 +22,14 @@ jobs:
         with:
           fail: true
           args: >
-            --glob-ignore-case 
+            --exclude-path _extensions
             --exclude docs\.google\.com 
             --exclude hackmd\.io 
             --exclude github\.com\/orgs\/cct-datascience\/projects 
             --exclude calendar\.google\.com 
             --exclude \.php$ 
             --exclude portal\.hpc\.arizona\.edu
+            --glob-ignore-case 
             './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File


### PR DESCRIPTION
Discovered the `--exclude-path` argument for `lychee` and used it to not check `_extensions/` for broken links.