### PR TITLE
make repo-action links open in a new tab (#91)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,7 +30,7 @@ jobs:
             --exclude \.php$ 
             --exclude portal\.hpc\.arizona\.edu
             --glob-ignore-case 
-            --max-concurrency 5
+            --accept '200..=204, 429'
             './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,6 +30,7 @@ jobs:
             --exclude \.php$ 
             --exclude portal\.hpc\.arizona\.edu
             --glob-ignore-case 
+            --max-concurrency 5
             './**/*.md' './**/*.qmd'
 
       - name: Create Issue From File

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -48,6 +48,7 @@ book:
   site-url: https://cct-datascience.github.io/group-procedures/
   repo-url: https://github.com/cct-datascience/group-procedures
   repo-actions: [edit, issue, source]
+  repo-link-target: "_blank" #causes rep-actions links to open in a new tab
   issue-url: https://github.com/cct-datascience/group-procedures/issues/new?template=suggest-edit.md
   chapters:
     - index.qmd


### PR DESCRIPTION
## Technical changes/additions

makes repo-action links (report issue, edit this page, view source) open in a new tab. Closes #91 