### PR TITLE
increase max-retries from 3 (default) to 5

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fail: true
           args: >
+            --max-retries 5
             --exclude-path _extensions
             --exclude docs\.google\.com 
             --exclude hackmd\.io 


### PR DESCRIPTION
## Technical changes/additions

Increases the maximum number of retries for the link checker action from 3 to 5, which will hopefully give fewer false negatives due to transient connection errors.