### PR TITLE
Addresses URL issues in #110

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,6 +31,7 @@ jobs:
             --exclude calendar\.google\.com 
             --exclude \.php$ 
             --exclude portal\.hpc\.arizona\.edu
+            --exclude dev\.mysql\.com\/downloads\/connector\/odbc
             --glob-ignore-case 
             --accept '200..=204, 429'
             './**/*.md' './**/*.qmd'

--- a/group-procedures.Rproj
+++ b/group-procedures.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 1b796bc6-4832-42ce-aa45-c9cddc45c571
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/quarterly-meetings.qmd
+++ b/quarterly-meetings.qmd
@@ -55,7 +55,7 @@ This is also a time for general discussion about group vision, projects, funding
 ## OKRs (Objectives and Key Results)
 
 OKRs are a framework for goalsetting developed and used by Google.
-You can learn more about OKRs from [whatmatters.com](https://www.whatmatters.com/get-started)
+You can learn more about OKRs from [whatmatters.com](https://www.whatmatters.com)
 
 Each member has their own set of OKRs per quarter, and there also may be group OKRs.
 They should all have quantifiable, specific outcomes, and should also be stretch goals.


### PR DESCRIPTION
## Content changes/additions

The "getting started" page at whatmatters.com about OKRs has disappeared with no re-direct.  I just link to their homepage instead.

## Technical changes/additions

Excludes https://dev.mysql.com/downloads/connector/odbc/ from the lychee URL checker action since it seems to work fine as a human clicking the link, but gets consistent 403 errors when run on GitHub actions.